### PR TITLE
Add video for testing timestamp labels and frame labels in VideoReader

### DIFF
--- a/db/video/frame_num_timestamp/README.rst
+++ b/db/video/frame_num_timestamp/README.rst
@@ -1,0 +1,11 @@
+
+Video files used for tests were generated with command below:
+
+.. code-block:: bash
+
+  #!/bin/bash
+  # Create a 256 second video at 1fps at constant frame rate.
+  # This video has the property that luma = blue chroma = red chroma = frame timestamp = frame number
+  ffmpeg -f lavfi  -i  "nullsrc='s=512x512:d=256:r=1',scale=out_range=full,geq='lum=N:cb=N:cr=N',format=yuv420p,drawtext=fontfile=Arial.ttf: text=%{n}: x=(w-tw)/2: y=h-(2*lh): fontsize=20: fontcolor=white: box=1: boxcolor=0x00000099" test.mp4
+  # Create a 10 second video, at 25 fps constant frame rate.
+  ffmpeg -f lavfi  -i  "nullsrc='s=512x512:d=10:r=25',scale=out_range=full,format=yuv420p,drawtext=fontfile=Arial.ttf: text=%{n}: x=(w-tw)/2: y=h-(2*lh): fontsize=20: fontcolor=white: box=1: boxcolor=0x00000099" test_25fps.mp4

--- a/db/video/frame_num_timestamp/test.mp4
+++ b/db/video/frame_num_timestamp/test.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30e3ff1b1e4b32b05b8995dd4674d7dfc1f3bbd613659165e291a978e10ebd6a
+size 66123

--- a/db/video/frame_num_timestamp/test_25fps.mp4
+++ b/db/video/frame_num_timestamp/test_25fps.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b395823444c0fedf13747d124337ab9668d527fcf9bdb42afa92afd4309d215
+size 36933


### PR DESCRIPTION
Description: Since the R,G,B values in this video for each
frame is the frame number/timestamp itself. It can be used
to verify timestamp/frame number based labelling in
VideoReader, by matching the color with the returned labels.

Required in https://github.com/NVIDIA/DALI/pull/1500

Signed-off-by: Abhishek Sansanwal <asansanwal@nvidia.com>