### PR TITLE
Add video for example

### DIFF
--- a/db/video/README.rst
+++ b/db/video/README.rst
@@ -13,5 +13,7 @@ Video files used for tests were generated with command below:
   # Transcode video to 25fps at variable frame rate.
   # 180 frames, time deltas spaced between 1/30ms and 1/20ms. Duration ~7s.
   ffmpeg -i cfr_test.mp4 -vsync vfr -vf setpts='N/(25*TB)' vfr_test.mp4
+  # Create a 10 second 25fps constant frame rate video with the frame number burned into the frame at the bottom and the timestsamp at the top
+  ffmpeg -f lavfi  -i  "nullsrc='s=512x512:d=10:r=25',geq='r=0:g=0:b=0',scale=out_range=full,format=yuv420p,drawtext=fontfile=Arial.ttf: text=%{n}: x=(w-tw)/2: y=h-(2*lh): fontsize=20: fontcolor=white: box=1: boxcolor=0x00000099, drawtext=fontfile=Arial.ttf: text=%{pts}: x=(w-tw)/2: y=2*lh: fontsize=20: fontcolor=white: box=1: boxcolor=0x00000099" test_label.mp4
 
 provided in the issue in the main DALI repository (https://github.com/NVIDIA/DALI/issues/1041).

--- a/db/video/test_label.mp4
+++ b/db/video/test_label.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb18415ab760c3f6ad5b63951730c6976eb364fa0048a4b2b0d5a797a53f1d9c
+size 58369


### PR DESCRIPTION
Description: Used in example demonstrating
frame number and timestamp output from VideoReader.

Signed-off-by: Abhishek Sansanwal <asansanwal@nvidia.com>