### PR TITLE
Add corrupted video file

### DIFF
--- a/db/video/corrupted/moov_atom_not_found.mp4
+++ b/db/video/corrupted/moov_atom_not_found.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c638bb28e47a343395b6ddad25e4f766b811b2809ebda5f16e0ce7240912ace
+size 786480


### PR DESCRIPTION
$ ffprobe -find_stream_info moov_atom_not_found.mp4

Returns:

  [mov,mp4,m4a,3gp,3g2,mj2 @ 0x55a217efd080] moov atom not found
  corrupted.mp4: Invalid data found when processing input

Created from: sintel/video_files/sintel_trailer-720p_0.mp4

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>