### PR TITLE
Add small videos for checkpointing tests

### DIFF
--- a/db/video/small/small0.mp4
+++ b/db/video/small/small0.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28c64bbc9817de652c6cdc65ea2d53ba776db21f937ca63ad672cd708b0018dc
+size 81326

--- a/db/video/small/small1.mp4
+++ b/db/video/small/small1.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74f46bd9bf350b673c6e4704ca6387854f80a8b773f5288528ba112e4dafc5fe
+size 77986

--- a/db/video/small/small2.mp4
+++ b/db/video/small/small2.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e83572162800238a7412ebd5cc154de7aa683c5aba0f1e85a802dafc9fcb45ec
+size 81597

--- a/db/video/small/small3.mp4
+++ b/db/video/small/small3.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba61bdb452853f94f1b7a4607670ffa738f16009f1e2322da51ecf528c6d8360
+size 80816

--- a/db/video/small/small4.mp4
+++ b/db/video/small/small4.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b6eab2f00e4050703c5ee7c32bd9439c7a5dc75c3ecb896407870dee4626be5
+size 77938


### PR DESCRIPTION
This PR adds few low resolution (64x64) videos with random noise. They're intended for use in checkpointing tests, where we just want to check if the correct frames are produced. Using those small videos makes video reader checkpointing tests (which are responsible for 60% of checkpointing tests duration) **15x faster**. 

See https://github.com/NVIDIA/DALI/pull/5305